### PR TITLE
Default to DOUBLE when extracting value type

### DIFF
--- a/prometheus-to-sd/build_and_deploy.sh
+++ b/prometheus-to-sd/build_and_deploy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TAG=${1:-}
+if [[ -z $TAG ]]; then
+  echo "Missing image tag paramter."
+  exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/"
+cd $SCRIPT_DIR
+docker build . -t docker.artifactory.cloudkitchens.internal/prometheus-to-sd-internal:${TAG}
+docker push docker.artifactory.cloudkitchens.internal/prometheus-to-sd-internal:${TAG}

--- a/prometheus-to-sd/translator/translator.go
+++ b/prometheus-to-sd/translator/translator.go
@@ -311,7 +311,7 @@ func extractValueType(mType dto.MetricType, originalDescriptor *v3.MetricDescrip
 	if mType == dto.MetricType_HISTOGRAM {
 		return "DISTRIBUTION"
 	}
-	return "INT64"
+	return "DOUBLE"
 }
 
 func extractAllLabels(family *dto.MetricFamily, originalDescriptor *v3.MetricDescriptor) []*v3.LabelDescriptor {


### PR DESCRIPTION
Double has enough precision for all the things we want to count and also can handle decimal points